### PR TITLE
Fix little bug in function logsize

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -124,7 +124,7 @@ function generateOneof(generators) {
 
 // Helper, essentially: log2(size + 1)
 function logsize(size) {
-  return Math.max(Math.round(Math.log(size + 1) / Math.log(2), 0));
+  return Math.max(Math.round(Math.log(size + 1) / Math.log(2)), 0);
 }
 
 /**


### PR DESCRIPTION
An argument turned up inside wrong function call because of confused right parenthesis